### PR TITLE
Tilelist tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ node_modules
 
 # Optional REPL history
 .node_repl_history
+
+# Tile list scripts
+feature.json
+streets.mbtiles

--- a/bin/geojson-to-border-tiles.js
+++ b/bin/geojson-to-border-tiles.js
@@ -1,0 +1,89 @@
+// Given a polygon or multipolygon, find all the tiles that intersect the border
+// at zoom levels 0 through 14
+
+var exp = require('../support/expander');
+var fs = require('fs');
+var tc = require('tile-cover');
+var _ = require('underscore');
+
+// Provide output filename as argument
+var featurePath = process.argv[2];
+var output = process.argv[3];
+
+var line;
+var feature = JSON.parse(fs.readFileSync(featurePath, 'utf8'));
+if (feature.geometry.type === 'Polygon') {
+  line = polygonToLinestring(feature);
+} else if (feature.geometry.type === 'MultiPolygon') {
+  line = multiPolygonToMultiLinestring(feature);
+} else {
+  throw new Error('Invalid input geometry type');
+}
+
+var tiles = tc.tiles(line.geometry, { min_zoom: 14, max_zoom: 14 });
+var unique = deduplicate(tiles);
+var allZooms = addLowZooms(line, unique);
+fs.writeFileSync(output, allZooms);
+
+function multiPolygonToMultiLinestring (multipolygon) {
+  var coordinates = [];
+  for (var i = 0; i < multipolygon.geometry.coordinates.length; i++) {
+    coordinates.push(multipolygon.geometry.coordinates[i][0]);
+  }
+  var multilinestring = {"type":"Feature","properties":{},"geometry":{"type":"MultiLineString","coordinates":coordinates}};
+  return multilinestring;
+}
+
+function polygonToLinestring (polygon) {
+  var coordinates = polygon.geometry.coordinates[0];
+  var linestring = {"type":"Feature","properties":{},"geometry":{"type":"LineString","coordinates":coordinates}};
+  return linestring;
+}
+
+function deduplicate (array) {
+  var unique = {};
+  for (var i = 0; i < tiles.length; i++) {
+    unique = expander(tiles[i], unique);
+  };
+  
+  var result = getString(unique);
+  return result;
+}
+
+function expander (array, object) {
+  var zxy = [];
+  var results = [];
+  zxy[0] = array[2];
+  zxy[1] = array[0];
+  zxy[2] = array[1];
+
+  var buffered = exp.buffered(zxy);
+  var parents = exp.parents(zxy);
+  var result = buffered.concat(parents);
+
+  for (var i = 0; i < result.length; i++) {
+    if (!object.hasOwnProperty(result[i])) {
+      object[result[i]] = true;
+    }
+  }
+  return object;
+};
+
+function getString (object) {
+  var keys = _.keys(object);
+  keys.sort();
+  var result = keys.join('\n');
+  return result;
+};
+
+function addLowZooms (line, string) {
+  var result = '';
+  for (var i = 0; i < 4; i++) {
+    var tiles = tc.tiles(line.geometry, { min_zoom: i, max_zoom: i });
+    for (var j = 0; j < tiles.length; j++) {
+      var zxy = [ tiles[j][2], tiles[j][0], tiles[j][1] ];
+      result += zxy.join('/') + ('\n');      
+    }
+  }
+  return string + '\n' + result;
+}

--- a/bin/mbtiles-to-tile-list.js
+++ b/bin/mbtiles-to-tile-list.js
@@ -1,0 +1,57 @@
+// Given an MBTiles file and a polygon or multipolygon feature,
+// generate a list of tiles that do not intersect with the multipolygon
+
+var fs = require('fs');
+var intersect = require('turf-intersect');
+var mbtiles = require('mbtiles');
+var stream = require('stream');
+var tilebelt = require('tilebelt').tileToGeoJSON;
+
+// Provide feature path, intput filename, and output filename as arguments
+var featurePath = process.argv[2];
+var input = process.argv[3];
+var output = process.argv[4];
+
+var file = fs.createWriteStream(output);
+new mbtiles(input, function (err, src) {
+  if (err) throw err;
+  var stream = src.createZXYStream();
+  stream.pipe(removeFeatureTiles).pipe(file);
+})
+
+var removeFeatureTiles = new stream.Transform();
+removeFeatureTiles._transform = function (chunk, enc, callback) {
+  var feature = JSON.parse(fs.readFileSync(featurePath, 'utf8'));
+  var filtered = tileFormat(chunk, feature);
+  removeFeatureTiles.push(filtered);
+  callback();
+}
+
+function tileFormat (chunk, feature) {
+  var result = '';
+  var array = chunk.toString().split('\n');
+  for (var i = 0; i < array.length; i++) {
+    if (array[i] !== '') {
+      var intersections = 0;
+      var zxy = array[i].split('/');
+      var xyz = [ Number(zxy[1]), Number(zxy[2]), Number(zxy[0]) ];
+      var geojson = tilebelt(xyz);
+      for (var j = 0; j < feature.geometry.coordinates.length; j++) {
+        var polygon;
+        if (feature.geometry.type === 'Polygon') {
+          polygon = {"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[ feature.geometry.coordinates[j] ]}};
+        } else {
+          polygon = {"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":feature.geometry.coordinates[j]}};
+        };
+        if (intersect(polygon ,geojson) !== undefined) {
+          intersections++;
+        }
+      }
+      if (intersections === 0) {
+        result += array[i] + '\n';
+      }
+    }
+  }
+  return result;
+}
+

--- a/bin/tile-list-to-geojson.js
+++ b/bin/tile-list-to-geojson.js
@@ -1,0 +1,34 @@
+// Given a list of tiles, generate a list of GeoJSON tile features
+
+var fs = require('fs');
+var stream = require('stream');
+var convertToGeoJSON = new stream.Transform();
+var tilebelt = require('tilebelt').tileToGeoJSON;
+
+// Provide input filename, output filename, and zoom as arguments
+var input = process.argv[2];
+var output = process.argv[3];
+var zoom = Number(process.argv[4]);
+
+var output = fs.createWriteStream(output);
+var input = fs.createReadStream(input);
+input.on('open', function() {
+  input.pipe(convertToGeoJSON).pipe(output);
+})
+
+convertToGeoJSON._transform = function (chunk, enc, callback) {
+  var result = '';
+  var tiles = chunk.toString().split('\n');
+  for (var i = 0; i < tiles.length; i++) {
+    var zxy = tiles[i].split('/');
+    var xyz = [ Number(zxy[1]), Number(zxy[2]), Number(zxy[0]) ];
+    var geojson = tilebelt(xyz);
+    geojson.properties = {};
+    geojson.properties.zoom = xyz[2];
+    if (Number(geojson.properties.zoom) === zoom) {
+      result += JSON.stringify(geojson) + '\n';
+    }
+  }
+  convertToGeoJSON.push(result);
+  callback();
+}

--- a/package.json
+++ b/package.json
@@ -10,9 +10,16 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "d3-queue": "^2.0.3",
+    "lineclip": "^1.1.5",
+    "mbtiles": "^0.9.0",
     "point-in-polygon": "^1.0.0",
     "sphericalmercator": "^1.0.5",
     "sqlite3": "^3.1.4",
+    "stream": "0.0.2",
+    "tile-cover": "^3.0.1",
+    "tilebelt": "^1.0.1",
+    "turf-intersect": "^3.0.10",
+    "underscore": "^1.8.3",
     "yargs": "^4.7.1"
   },
   "devDependencies": {

--- a/support/expander.js
+++ b/support/expander.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+var minzoom = 4;
+
+module.exports = {};
+module.exports.parents = parents;
+module.exports.buffered = buffered;
+
+// For parent tiles, buffer only the 3 tiles around each quadrant corner.
+// This assumes no layer buffer is > 128 (half the tile extent).
+// Example for nw corner:
+//
+// +-------+-------+........
+// |       |       |       .
+// |       |       |       .
+// |       |       |       .
+// +-------+---+---+       .
+// |       |  x|   |       .
+// |       +---+---+ <--------- nw,ne,sw,se quadrants of parent tile
+// |       |   |   |       .    if feature is in nw child, only the
+// +-------+---+---+       .    3 adjacent corner parents need to be
+// .                       .    considered.
+// .                       .
+// .                       .
+// .........................
+//
+function parents(zxy) {
+    var expire = [];
+
+    if (zxy[0] <= minzoom) return expire;
+
+    var pxy = [zxy[0] - 1, Math.floor(zxy[1]/2), Math.floor(zxy[2]/2)];
+    var clip = makeClipper(pxy[0]);
+    expire.push(pxy[0] + '/' + clip(pxy[1] + 0) + '/' + clip(pxy[2] + 0));
+    // nw corner
+    if (zxy[1]%2 === 0 && zxy[2]%2 === 0) {
+        expire.push(pxy[0] + '/' + clip(pxy[1] - 1) + '/' + clip(pxy[2] - 1));
+        expire.push(pxy[0] + '/' + clip(pxy[1] - 1) + '/' + clip(pxy[2] - 0));
+        expire.push(pxy[0] + '/' + clip(pxy[1] - 0) + '/' + clip(pxy[2] - 1));
+    // ne corner
+    } else if (zxy[1]%2 === 1 && zxy[2]%2 === 0) {
+        expire.push(pxy[0] + '/' + clip(pxy[1] + 1) + '/' + clip(pxy[2] - 1));
+        expire.push(pxy[0] + '/' + clip(pxy[1] + 1) + '/' + clip(pxy[2] - 0));
+        expire.push(pxy[0] + '/' + clip(pxy[1] + 0) + '/' + clip(pxy[2] - 1));
+    // sw corner
+    } else if (zxy[1]%2 === 0 && zxy[2]%2 === 1) {
+        expire.push(pxy[0] + '/' + clip(pxy[1] - 1) + '/' + clip(pxy[2] + 1));
+        expire.push(pxy[0] + '/' + clip(pxy[1] - 1) + '/' + clip(pxy[2] + 0));
+        expire.push(pxy[0] + '/' + clip(pxy[1] - 0) + '/' + clip(pxy[2] + 1));
+    // se corner
+    } else if (zxy[1]%2 === 1 && zxy[2]%2 === 1) {
+        expire.push(pxy[0] + '/' + clip(pxy[1] + 1) + '/' + clip(pxy[2] + 1));
+        expire.push(pxy[0] + '/' + clip(pxy[1] + 1) + '/' + clip(pxy[2] + 0));
+        expire.push(pxy[0] + '/' + clip(pxy[1] + 0) + '/' + clip(pxy[2] + 1));
+    }
+    expire = expire.concat(parents(pxy));
+    return expire;
+}
+
+function makeClipper(z) {
+    var m = Math.pow(2, z) - 1;
+    return function(num) {
+        return Math.max(0, Math.min(m, num));
+    };
+}
+
+// At maxzoom, full 1-tile buffer around all sizes.
+function buffered(zxy) {
+    var clip = makeClipper(zxy[0]);
+    return [
+        zxy[0] + '/' + clip(zxy[1] - 1) + '/' + clip(zxy[2] - 1),
+        zxy[0] + '/' + clip(zxy[1] - 1) + '/' + clip(zxy[2] + 0),
+        zxy[0] + '/' + clip(zxy[1] - 1) + '/' + clip(zxy[2] + 1),
+        zxy[0] + '/' + clip(zxy[1] + 0) + '/' + clip(zxy[2] - 1),
+        zxy[0] + '/' + clip(zxy[1] + 0) + '/' + clip(zxy[2] + 0),
+        zxy[0] + '/' + clip(zxy[1] + 0) + '/' + clip(zxy[2] + 1),
+        zxy[0] + '/' + clip(zxy[1] + 1) + '/' + clip(zxy[2] - 1),
+        zxy[0] + '/' + clip(zxy[1] + 1) + '/' + clip(zxy[2] + 0),
+        zxy[0] + '/' + clip(zxy[1] + 1) + '/' + clip(zxy[2] + 1)
+    ];
+}
+
+if (!module.parent) process.stdin
+    .pipe(require('split')())
+    .on('data', function(line) {
+        if (!line) return;
+
+        var zxy = line.split('/');
+        zxy[0] = parseInt(zxy[0], 10);
+        zxy[1] = parseInt(zxy[1], 10);
+        zxy[2] = parseInt(zxy[2], 10);
+
+        var expire = buffered(zxy).concat(parents(zxy));
+        for (var i = 0; i < expire.length; i++) {
+            console.log(expire[i]);
+        }
+    });


### PR DESCRIPTION
This PR tracks the addition of 3 tools:
- [`geojson-to-border-tiles.js`](https://github.com/mapbox/mbtiles-cutout/blob/1b7d66cbd13d923856364696091abc4e4226bd26/bin/geojson-to-border-tiles.js): Converts a GeoJSON feature to a list of border tiles. Required params:
  - Filepath to GeoJSON feature to exclude (polygon or multipolygon)
  - Filepath to desired output
- [`mbtiles-to-tile-list.js`](https://github.com/mapbox/mbtiles-cutout/blob/1b7d66cbd13d923856364696091abc4e4226bd26/bin/mbtiles-to-tile-list.js): Converts an MBTiles file into a tile list. Required params:
  - Filepath to GeoJSON feature to exclude (polygon or multipolygon)
  - Filepath to MBTiles file input
  - Filepath to desired output
- [`tile-list-to-geojson`](https://github.com/mapbox/mbtiles-cutout/blob/1b7d66cbd13d923856364696091abc4e4226bd26/bin/tile-list-to-geojson.js): Converts a list of tiles into a list of GeoJSON features. Required params:
  - Filepath to tilelist file input (zxy\n format)
  - Filepath to desired output
  - Desired tile zoom level

To do:
- [ ] Write tests

cc @rclark @willwhite 
